### PR TITLE
Pass media-type as a Content-Type header

### DIFF
--- a/lib/openapi_rspec/request_validator.rb
+++ b/lib/openapi_rspec/request_validator.rb
@@ -60,18 +60,21 @@ module OpenapiRspec
     end
 
     def perform_request(doc)
+      header("Content-Type", media_type)
       headers.each do |key, value|
-        header key, value
+        header(key, value)
       end
-      request(request_uri(doc), method: method, **request_params)
+      request(request_uri(doc), method: method, headers: headers, **request_params)
       @response = last_response
     end
 
     def request_params
-      {
-        headers: headers,
-        params: params,
-      }
+      case media_type
+      when "application/json"
+        {input: JSON.dump(params)}
+      else
+        {params: params}
+      end
     end
   end
 end

--- a/spec/example_spec.rb
+++ b/spec/example_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe "API v1" do
   # do not forget additional_schemas
   subject { OpenapiRspec.api("./spec/data/openapi.yml", api_base_path: "/v1") }
 
+  media_type { "application/json" }
+
   it "is valid openapi spec" do
     expect(subject).to validate_documentation
   end


### PR DESCRIPTION
- [x] Pass params as json body when `Content-Type` of the request set to `application/json`
- [ ] Deferentiate `Content-Type` headers for request and response